### PR TITLE
Remove manpage references to OpenBSD-specific functions

### DIFF
--- a/signify.1
+++ b/signify.1
@@ -162,10 +162,6 @@ Verify a bsd.rd before an upgrade:
 .Bd -literal -offset indent -compact
 $ signify -C -p /etc/signify/openbsd-56-base.pub -x SHA256.sig bsd.rd
 .Ed
-.Sh SEE ALSO
-.Xr fw_update 1 ,
-.Xr pkg_add 1 ,
-.Xr sha256 1
 .Sh HISTORY
 The
 .Nm


### PR DESCRIPTION
The "see also" section of the manpage for signify references many functions that are exlusive to OpenBSD. Given that this is the portable version of signify, I propose that these references should be removed.
