### PR TITLE
Escape hyphens to turn them into minuses

### DIFF
--- a/signify.1
+++ b/signify.1
@@ -155,12 +155,12 @@ Verify a release directory containing
 .Pa SHA256.sig
 and a full set of release files:
 .Bd -literal -offset indent -compact
-$ signify -C -p /etc/signify/openbsd-56-base.pub -x SHA256.sig
+$ signify \-C \-p /etc/signify/openbsd-56-base.pub \-x SHA256.sig
 .Ed
 .Pp
 Verify a bsd.rd before an upgrade:
 .Bd -literal -offset indent -compact
-$ signify -C -p /etc/signify/openbsd-56-base.pub -x SHA256.sig bsd.rd
+$ signify \-C \-p /etc/signify/openbsd-56-base.pub \-x SHA256.sig bsd.rd
 .Ed
 .Sh SEE ALSO
 .Xr fw_update 1 ,


### PR DESCRIPTION
Hi! I'm trying to package signify for Debian, and this error tag came up:
https://lintian.debian.org/tags/hyphen-used-as-minus-sign.html

It seems that the manpage for signify uses hyphens in places where minus signs should have been used instead.
