### PR TITLE
Make explicit that OpenBSD's signing keys are not present in other OSs

### DIFF
--- a/signify.1
+++ b/signify.1
@@ -156,6 +156,8 @@ Verify a release directory containing
 and a full set of release files:
 .Bd -literal -offset indent -compact
 $ signify \-C \-p /etc/signify/openbsd-56-base.pub \-x SHA256.sig
+Note that for non-OpenBSD operating systems, you will have to get the
+signing key yourself.
 .Ed
 .Pp
 Verify a bsd.rd before an upgrade:


### PR DESCRIPTION
I know that this seems pedantic, but in the process of my package being reviewed for Debian, it has been noted that OpenBSD's signing keys are not (and should not be) shipped with the package. This pull request fixes that.

Oh, and may you have a happy new year, filled with fun, success and cryptography. :)
