### PR TITLE
Fix explict_bzero.c to do what it's supposed to do.

### DIFF
--- a/cvs-files
+++ b/cvs-files
@@ -7,7 +7,6 @@ src/lib/libc/hash/sha2.c
 src/lib/libc/hash/helper.c
 src/lib/libc/net/base64.c
 src/lib/libc/string/timingsafe_bcmp.c
-src/lib/libc/string/explicit_bzero.c
 
 src/lib/libutil/ohash.h
 src/lib/libutil/ohash.c


### PR DESCRIPTION
The point of explcit_bzero is that it doesn't get optimized out by the compilers dead store optimization. In cryptographer applications dead store is counterproductive because it leaves key material in memory. OpenBSD implemented explict_bzero to stop this happening but just using the file from src/libc, will not do the job because they also implemented a compiler hook. Without the compiler hook this results in a stright call to memset, which dead store may optimize away. This patch implements it in a way that is portable.