### PR TITLE
Fix memory corruption due to compat.h defines.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 signify
 signify.1.gz
 sha512hl.c
+sha512_256hl.c
 sha256hl.c
 /libbsd-*

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ S := crypto_api.c \
 	 sha2.c \
 	 sha256hl.c \
 	 sha512hl.c \
+	 sha512_256hl.c \
 	 signify.c \
 	 zsig.c
 
@@ -196,7 +197,7 @@ signify: $O $(LIBBSD_DEPS)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBBSD_LDFLAGS) $(LDLIBS)
 
 clean-signify:
-	$(RM) $O signify signify.1.gz sha256hl.c sha512hl.c
+	$(RM) $O signify signify.1.gz sha256hl.c sha512hl.c sha512_256hl.c
 
 clean: clean-signify
 .PHONY: clean-signify
@@ -213,6 +214,11 @@ sha512hl.c: helper.c
 	sed -e 's/hashinc/sha2.h/g' \
 	    -e 's/HASH/SHA512/g' \
 	    -e 's/SHA[0-9][0-9][0-9]_CTX/SHA2_CTX/g' $< > $@
+
+sha512_256hl.c:	helper.c
+	sed -e 's/hashinc/sha2.h/g' \
+	    -e 's/HASH/SHA512_256/g' \
+	    -e 's/SHA512_256_CTX/SHA2_CTX/g' $< > $@
 
 install: signify signify.1.gz
 	install -m 755 -d $(DESTDIR)$(PREFIX)/bin

--- a/compat.h
+++ b/compat.h
@@ -25,19 +25,9 @@
 #define __dead
 #endif /* !__dead */
 
-#define DEF_WEAK(a)
-#define MAKE_CLONE(a, b)
-
-#define SHA224Transform     SHA256Transform
-#define SHA224Update        SHA256Update
-#define SHA224Pad           SHA256Pad
-#define SHA384Transform     SHA512Transform
-#define SHA384Update        SHA512Update
-#define SHA384Pad           SHA512Pad
-#define SHA512_256Transform SHA512Transform
-#define SHA512_256Update    SHA512Update
-#define SHA512_256Pad       SHA512Pad
-#define SHA512_256Data      SHA512Data
+#define DEF_WEAK(x)
+#define MAKE_CLONE(dst, src)	typeof(dst) dst \
+				__attribute__((alias (#src)))
 
 #include <stdint.h>
 #include <stddef.h>


### PR DESCRIPTION
Fix for #17.

Uses the alias logic from OpenBSD without the `_libc_` modification.