### PR TITLE
Include license file

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,16 @@
+Copyright (c) 2013 Ted Unangst <tedu@openbsd.org>
+Copyright (c) 2016 Marc Espie <espie@openbsd.org>
+Copyright (c) 2019 Adrian Perez de Castro <aperez@igalia.com>
+Copyright (c) 2019 Scott Bennett and other contributors
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
Linux distros require licensing information to be distributed alongside the installed (binary) package – hence the need for a separate file.