### PR TITLE
Fix musl-static / static-musl target name typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,4 +254,4 @@ static:
 static-musl:
 	$(MAKE) EXTRA_CFLAGS='$(EXTRA_CFLAGS) -pthread' EXTRA_LDFLAGS='$(EXTRA_LDFLAGS) -pthread -static' MUSL=1 CC=musl-gcc LD=musl-gcc
 
-.PHONY: static musl-static
+.PHONY: static static-musl


### PR DESCRIPTION
I think this was the intended .PHONY dependency

Please advise if you want the contribution done in any other way