### PR TITLE
Fix build with clang 16

### DIFF
--- a/base64.c
+++ b/base64.c
@@ -52,6 +52,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "base64.h"
 
 static const char Base64[] =
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/base64.h
+++ b/base64.h
@@ -1,0 +1,2 @@
+int b64_pton(char const *, unsigned char *, size_t);
+int b64_ntop(unsigned char const *, size_t , char *, size_t);

--- a/signify.c
+++ b/signify.c
@@ -34,6 +34,7 @@
 #include "sha2.h"
 
 #include "crypto_api.h"
+#include "base64.h"
 #include "signify.h"
 
 #define SIGBYTES crypto_sign_ed25519_BYTES


### PR DESCRIPTION
Clang 16 (and likely GCC 13) enables -Wimplicit-function-declaration by default. This results in errors such as:

signify.c:144:6: error: call to undeclared function 'b64_pton'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (b64_pton(commentend + 1, buf, buflen) != buflen)
            ^
signify.c:231:6: error: call to undeclared function 'b64_ntop'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (b64_ntop(buf, buflen, b64, sizeof(b64)) == -1)
            ^
signify.c:624:12: error: call to undeclared function 'b64_pton'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if ((rv = b64_pton(hash, data, sizeof(data))) == -1)

A simple fix is to create a base64.h file containing the headers of the b64_* functions.

Bug: https://bugs.gentoo.org/894354